### PR TITLE
NotEqualOperator - changed to identity comparison

### DIFF
--- a/source/operators/NotEqualOperator.php
+++ b/source/operators/NotEqualOperator.php
@@ -40,6 +40,6 @@ class NotEqualOperator extends AbstractPHPPreBinaryOperator
 {
     public function getValue()
     {
-        return $this->left->getValue() != $this->right->getValue();
+        return $this->left->getValue() !== $this->right->getValue();
     }
 }


### PR DESCRIPTION
I think it should be `!==` not `!=`.
